### PR TITLE
remove '.git' from bower dep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bower-dummy",
   "devDependencies": {
-    "ember-validations": "kristianmandrup/ember-validations.git#master"
+    "ember-validations": "kristianmandrup/ember-validations#master"
   }
 }


### PR DESCRIPTION
Fixes npm install error where it can't find the bower dep
